### PR TITLE
Update predict.py

### DIFF
--- a/layer_recognition/app/train_predict/predict.py
+++ b/layer_recognition/app/train_predict/predict.py
@@ -54,7 +54,7 @@ from layer_recognition.ml.utils import get_classes_and_features
     "--distinguishable-second-layer",
     "-d",
     is_flag=True,
-    default=True,
+    default=False,
     help="Treats layer 2 and 3 as separate layers.",
 )
 @click.option(


### PR DESCRIPTION
Bug correction: distinguish-second-layer flag must be False by default and set to True if the flag is set by the user.